### PR TITLE
Only install dependencies if we are compiling

### DIFF
--- a/NEBL-Pi-Installer.sh
+++ b/NEBL-Pi-Installer.sh
@@ -79,7 +79,7 @@ fi
 
 # update and install dependencies
 sudo apt-get update -y
-if [ "$COMPILE" = true ];
+if [ "$COMPILE" = true ]; then
     sudo apt-get install build-essential -y
     sudo apt-get install libboost-all-dev -y
     sudo apt-get install libdb++-dev -y
@@ -88,13 +88,13 @@ if [ "$COMPILE" = true ];
 fi
 if [ "$NEBLIOQT" = true ]; then
     sudo apt-get install qt5-default -y
-    if [ "$COMPILE" = true ];
+    if [ "$COMPILE" = true ]; then
         sudo apt-get install qt5-qmake -y
         sudo apt-get install qtbase5-dev-tools -y
         sudo apt-get install qttools5-dev-tools -y
     fi
 fi
-if [ "$COMPILE" = true ];
+if [ "$COMPILE" = true ]; then
     if [ "$JESSIE" = true ]; then
         sudo apt-get install libssl-dev -y
     else

--- a/NEBL-Pi-Installer.sh
+++ b/NEBL-Pi-Installer.sh
@@ -78,31 +78,28 @@ if [ "$QUICKSYNC" = true ]; then
 fi
 
 # update and install dependencies
-sudo apt-get update -y
 if [ "$COMPILE" = true ]; then
+    sudo apt-get update -y
     sudo apt-get install build-essential -y
     sudo apt-get install libboost-all-dev -y
     sudo apt-get install libdb++-dev -y
     sudo apt-get install libminiupnpc-dev -y
     sudo apt-get install libqrencode-dev -y
-fi
-if [ "$NEBLIOQT" = true ]; then
-    sudo apt-get install qt5-default -y
-    if [ "$COMPILE" = true ]; then
-        sudo apt-get install qt5-qmake -y
-        sudo apt-get install qtbase5-dev-tools -y
-        sudo apt-get install qttools5-dev-tools -y
-    fi
-fi
-if [ "$COMPILE" = true ]; then
     if [ "$JESSIE" = true ]; then
         sudo apt-get install libssl-dev -y
     else
         sudo aptitude install libssl1.0-dev -y
     fi
+    if [ "$NEBLIOQT" = true ]; then
+        sudo apt-get install qt5-default -y
+        sudo apt-get install qt5-qmake -y
+        sudo apt-get install qtbase5-dev-tools -y
+        sudo apt-get install qttools5-dev-tools -y
+    fi
+    sudo apt-get install git -y
 fi
+
 sudo apt-get install wget -y
-sudo apt-get install git -y
 
 if [ "$COMPILE" = true ]; then
     # delete our src folder and then remake it

--- a/NEBL-Pi-Installer.sh
+++ b/NEBL-Pi-Installer.sh
@@ -79,21 +79,27 @@ fi
 
 # update and install dependencies
 sudo apt-get update -y
-sudo apt-get install build-essential -y
-sudo apt-get install libboost-all-dev -y
-sudo apt-get install libdb++-dev -y
-sudo apt-get install libminiupnpc-dev -y
-sudo apt-get install libqrencode-dev -y
+if [ "$COMPILE" = true ];
+    sudo apt-get install build-essential -y
+    sudo apt-get install libboost-all-dev -y
+    sudo apt-get install libdb++-dev -y
+    sudo apt-get install libminiupnpc-dev -y
+    sudo apt-get install libqrencode-dev -y
+fi
 if [ "$NEBLIOQT" = true ]; then
     sudo apt-get install qt5-default -y
-    sudo apt-get install qt5-qmake -y
-    sudo apt-get install qtbase5-dev-tools -y
-    sudo apt-get install qttools5-dev-tools -y
+    if [ "$COMPILE" = true ];
+        sudo apt-get install qt5-qmake -y
+        sudo apt-get install qtbase5-dev-tools -y
+        sudo apt-get install qttools5-dev-tools -y
+    fi
 fi
-if [ "$JESSIE" = true ]; then
-    sudo apt-get install libssl-dev -y
-else
-    sudo aptitude install libssl1.0-dev -y
+if [ "$COMPILE" = true ];
+    if [ "$JESSIE" = true ]; then
+        sudo apt-get install libssl-dev -y
+    else
+        sudo aptitude install libssl1.0-dev -y
+    fi
 fi
 sudo apt-get install wget -y
 sudo apt-get install git -y

--- a/NEBL-Pi-Installer.sh
+++ b/NEBL-Pi-Installer.sh
@@ -96,10 +96,7 @@ if [ "$COMPILE" = true ]; then
         sudo apt-get install qtbase5-dev-tools -y
         sudo apt-get install qttools5-dev-tools -y
     fi
-    sudo apt-get install git -y
 fi
-
-sudo apt-get install wget -y
 
 if [ "$COMPILE" = true ]; then
     # delete our src folder and then remake it
@@ -171,6 +168,12 @@ if [ "$QUICKSYNC" = true ]; then
         cd ..
         rm -rf neblio-blockchain-data
     fi
+fi
+
+if [ "$NEBLIOQT" = true ]; then
+    echo ""
+    echo "Starting neblio-qt"
+    $HOME/Desktop/neblio-qt
 fi
 
 echo ""


### PR DESCRIPTION
Now that our linux builds are statically compiled we do not need to install dependencies unless we are compiling from source.

This makes the installation much much faster.